### PR TITLE
Removed odd defaults from configuration Fixes #3

### DIFF
--- a/src/main/java/me/cmastudios/permissions/Permissions.java
+++ b/src/main/java/me/cmastudios/permissions/Permissions.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.logging.Level;
 import me.cmastudios.permissions.commands.*;
 import org.bukkit.configuration.InvalidConfigurationException;
+import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.permissions.PermissionAttachment;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -44,6 +45,7 @@ public class Permissions extends JavaPlugin {
         }
         this.saveDefaultConfig();
         this.getConfig().options().copyDefaults(false);
+        this.getConfig().setDefaults(YamlConfiguration.loadConfiguration(new File("none"))); //Very very hacky
         this.connectDatabase();
         this.getCommand("setgroup").setExecutor(new SetGroupCommand(this));
     }


### PR DESCRIPTION
I didn't find any better solution for that, bukkit configuration management puts resourced config.yml as default stream when loading config.
setDefaults() doesn't accept null, so we must provide it empty config. 
